### PR TITLE
Correct the syntax of validate_legacy

### DIFF
--- a/manifests/validate_params.pp
+++ b/manifests/validate_params.pp
@@ -9,7 +9,7 @@ class easy_ipa::validate_params {
   }
 
   if $easy_ipa::ip_address != '' {
-    validate_legacy('String', 'validate_ip_address', $easy_ipa::ip_address)
+    validate_legacy(String, 'validate_ip_address', $easy_ipa::ip_address)
   }
 
   if $easy_ipa::manage_host_entry {
@@ -22,8 +22,8 @@ class easy_ipa::validate_params {
     fail('Parameter "idstart" must be an integer greater than 10000.')
   }
 
-  validate_legacy('String', 'validate_domain_name', $easy_ipa::domain)
-  validate_legacy('String', 'validate_domain_name', $easy_ipa::final_realm)
+  validate_legacy(String, 'validate_domain_name', $easy_ipa::domain)
+  validate_legacy(String, 'validate_domain_name', $easy_ipa::final_realm)
 
   if $easy_ipa::ipa_role == 'master' {
     if length($easy_ipa::admin_password) < 8 {
@@ -45,7 +45,7 @@ must be populated and at least of length 8."
       fail("When creating a ${easy_ipa::ipa_role} the parameter named ipa_master_fqdn cannot be empty.")
     }
 
-    validate_legacy('String', 'validate_domain_name', $easy_ipa::ipa_master_fqdn)
+    validate_legacy(String, 'validate_domain_name', $easy_ipa::ipa_master_fqdn)
 
     if $easy_ipa::final_domain_join_password == '' {
       fail("When creating a ${easy_ipa::ipa_role} the parameter named domain_join_password cannot be empty.")


### PR DESCRIPTION
The module fails to build an IPA server with the following error from
Puppet

> Error: Evaluation Error: Error while evaluating a Function Call, wrong
> number of arguments (2 for 1) at
> /tmp/vagrant-puppet/modules-b60d6b9b394060fa7321a0a40690f190/easy_ipa/manifests/validate_params.pp:25:3
> on node <redacted>.co.uk

With my patch the catalog sucessfully compiles. I couldn't replicate
this issue outside of this module however from a quick search on github
this looks to be the correct syntax to use.