### PR TITLE
Docs: no_ui_redirect logic is reversed

### DIFF
--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -71,9 +71,9 @@ class easy_ipa::install::server {
   }
 
   if $easy_ipa::no_ui_redirect {
-    $server_install_cmd_opts_no_ui_redirect = ''
-  } else {
     $server_install_cmd_opts_no_ui_redirect = '--no-ui-redirect'
+  } else {
+    $server_install_cmd_opts_no_ui_redirect = ''
   }
 
   if $easy_ipa::mkhomedir {


### PR DESCRIPTION
In the code for `manifests/install/server.pp` the logic for the UI
Redirect is backwards. I can't open any issues on this repo so I've made
this change the least intrusive. Ultimately I think the if statement
should be flipped to stick with the defaults within the
ipa-server-install script however that may introduce breaking changes to
others.

From the Docs:
> **no_ui_redirect**
> If true, then the parameter '--no-ui-redirect' is passed to the IPA
server installer.

From the code:
```
  if $easy_ipa::no_ui_redirect {
    $server_install_cmd_opts_no_ui_redirect = ''
  } else {
    $server_install_cmd_opts_no_ui_redirect = '--no-ui-redirect'
  }
```