### PR TITLE
Bump required version of puppetlabs/stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0"
+      "version_requirement": ">= 4.19.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The validate_domain_name function was added in puppetlabs/stdlib in
v4.19.0