### PR TITLE
Feature: Add option to setup ipa replica as a CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Name of the autofs package to install if enabled.
 If true, then the parameter '--setup-dns' is passed to the IPA server installer.
 Also, triggers the install of the required dns server packages.
 
+#### `configure_replica_ca`
+If true, then the parameter '--setup-ca' is passed to the IPA replica installer.
+
 #### `configure_ntp`
 If false, then the parameter '--no-ntp' is passed to the IPA server installer.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,9 @@
 #      (boolean) If true, then the parameter '--setup-dns' is passed to the IPA server installer.
 #                Also, triggers the install of the required dns server packages.
 #
+# `configure_replica_ca`
+#      (boolean) If true, then the parameter '--setup-ca' is passed to the IPA replica installer.
+#
 # `configure_ntp`
 #      (boolean) If false, then the parameter '--no-ntp' is passed to the IPA client and server
 #                installers.
@@ -153,6 +156,7 @@ class easy_ipa (
   Boolean       $no_dnssec_validation               = false,
   Boolean       $client_install_ldaputils           = false,
   Boolean       $configure_dns_server               = true,
+  Boolean       $configure_replica_ca               = false,
   Boolean       $configure_ntp                      = true,
   Boolean       $configure_sshd                     = true,
   Array[String] $custom_dns_forwarders              = [],

--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -47,6 +47,12 @@ class easy_ipa::install::server {
     $server_install_cmd_opts_setup_dns = ''
   }
 
+  if $easy_ipa::configure_replica_ca {
+    $server_install_cmd_opts_setup_ca = '--setup-ca'
+  } else {
+    $server_install_cmd_opts_setup_ca = ''
+  }
+
   if $easy_ipa::configure_ntp {
     $server_install_cmd_opts_no_ntp = ''
   } else {

--- a/manifests/install/server/replica.pp
+++ b/manifests/install/server/replica.pp
@@ -11,6 +11,7 @@ class easy_ipa::install::server::replica {
   ${easy_ipa::install::server::server_install_cmd_opts_zone_overlap} \
   ${easy_ipa::install::server::server_install_cmd_opts_dnssec_validation} \
   ${easy_ipa::install::server::server_install_cmd_opts_setup_dns} \
+  ${easy_ipa::install::server::server_install_cmd_opts_setup_ca} \
   ${easy_ipa::install::server::server_install_cmd_opts_forwarders} \
   ${easy_ipa::install::server::server_install_cmd_opts_ip_address} \
   ${easy_ipa::install::server::server_install_cmd_opts_no_ntp} \


### PR DESCRIPTION
From a setup of one master and one replica with the CA role being on just the master you get this warning:
> It is strongly recommended to keep the following services installed on more than one server:
> * CA

The following patch adds support for setting up a replica as a CA too by passing `--setup-ca` to the `ipa-replica-install` command. By default this is disabled.

It is however advised not to enable this on all replicas: https://www.redhat.com/archives/freeipa-users/2015-December/msg00275.html