### PR TITLE
Add option to pass --hostname flag to client installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The password for the domain_join_principal.
 
 #### `enable_hostname`
 If true, then the parameter '--hostname' is populated with the parameter 'ipa_server_fqdn'
-and passed to the IPA installer.
+and passed to the IPA installer. On client installs '--hostname' is populated with `$::fqdn`.
 
 #### `enable_ip_address`
 If true, then the parameter '--ip-address' is populated with the parameter 'ip_address'

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -40,6 +40,12 @@ class easy_ipa::install::client {
     $client_install_cmd_opts_no_sshd = '--no-sshd'
   }
 
+  if $easy_ipa::enable_hostname {
+    $client_install_cmd_opts_hostname = "--hostname=${::fqdn}"
+  } else {
+    $client_install_cmd_opts_hostname = ''
+  }
+
     $client_install_cmd = "\
 /usr/sbin/ipa-client-install \
   --server=${easy_ipa::ipa_master_fqdn} \
@@ -47,6 +53,7 @@ class easy_ipa::install::client {
   --domain=${easy_ipa::domain} \
   --principal='${easy_ipa::final_domain_join_principal}' \
   --password='${easy_ipa::final_domain_join_password}' \
+  ${client_install_cmd_opts_hostname} \
   ${client_install_cmd_opts_mkhomedir} \
   ${client_install_cmd_opts_fixed_primary} \
   ${client_install_cmd_opts_no_ntp} \


### PR DESCRIPTION
I'm not 100% this is the correct way to do this, mostly down to the variable naming.

The issue I was having is that ipa-client-install would get the fqdn of localhost.localdomain if `/etc/hosts` wasn't configured correctly. However, `$::fqdn` would always get the fqdn right.

It's Christmas, feel free to ignore this PR until Jan 🎄 