### PR TITLE
Add option to pass --setup-ca flag to replica installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Name of the autofs package to install if enabled.
 If true, then the parameter '--setup-dns' is passed to the IPA server installer.
 Also, triggers the install of the required dns server packages.
 
+#### `configure_replica_ca`
+If true, then the parameter '--setup-ca' is passed to the IPA replica installer.
+
 #### `configure_ntp`
 If false, then the parameter '--no-ntp' is passed to the IPA server installer.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,9 @@
 #      (boolean) If true, then the parameter '--setup-dns' is passed to the IPA server installer.
 #                Also, triggers the install of the required dns server packages.
 #
+# `configure_replica_ca`
+#      (boolean) If true, then the parameter '--setup-ca' is passed to the IPA replica installer.
+#
 # `configure_ntp`
 #      (boolean) If false, then the parameter '--no-ntp' is passed to the IPA client and server
 #                installers.
@@ -153,6 +156,7 @@ class easy_ipa (
   Boolean       $no_dnssec_validation               = false,
   Boolean       $client_install_ldaputils           = false,
   Boolean       $configure_dns_server               = true,
+  Boolean       $configure_replica_ca               = false,
   Boolean       $configure_ntp                      = true,
   Boolean       $configure_sshd                     = true,
   Array[String] $custom_dns_forwarders              = [],

--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -47,6 +47,12 @@ class easy_ipa::install::server {
     $server_install_cmd_opts_setup_dns = ''
   }
 
+  if $easy_ipa::configure_replica_ca {
+    $server_install_cmd_opts_setup_ca = '--setup-ca'
+  } else {
+    $server_install_cmd_opts_setup_ca = ''
+  }
+
   if $easy_ipa::configure_ntp {
     $server_install_cmd_opts_no_ntp = ''
   } else {

--- a/manifests/install/server/replica.pp
+++ b/manifests/install/server/replica.pp
@@ -11,6 +11,7 @@ class easy_ipa::install::server::replica {
   ${easy_ipa::install::server::server_install_cmd_opts_zone_overlap} \
   ${easy_ipa::install::server::server_install_cmd_opts_dnssec_validation} \
   ${easy_ipa::install::server::server_install_cmd_opts_setup_dns} \
+  ${easy_ipa::install::server::server_install_cmd_opts_setup_ca} \
   ${easy_ipa::install::server::server_install_cmd_opts_forwarders} \
   ${easy_ipa::install::server::server_install_cmd_opts_ip_address} \
   ${easy_ipa::install::server::server_install_cmd_opts_no_ntp} \


### PR DESCRIPTION
The CA would always be configure on the master, but not on any replicas which FreeIPA would give a warning for. This option adds allows for replicas to be setup as a CA also without having to do it manually after installation. 

It's recommended that the CA be ran on at least two FreeIPA servers, but due to the extra resources required, it isn't needed on all. I'll try to find source to this recommendation. Part of the reason it's not enabled by default.

---
It's Christmas, feel free to ignore this PR until Jan 🎄 