### PR TITLE
Fixes tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,12 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
+  forge_modules:
+    cron_core:
+      repo: "puppetlabs/cron_core"
+      ref: "1.0.0"
+      puppet_version: ">= 6.0.0"
+    k5login_core:
+      repo: "puppetlabs/k5login_core"
+      ref: "1.0.2"
+      puppet_version: ">= 6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
+  - gem update --system $RUBYGEMS_VERSION
   - gem update bundler
   - gem --version
   - bundle -v
@@ -31,7 +31,7 @@ matrix:
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
     -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec RUBYGEMS_VERSION=2.7.8
       rvm: 2.1.9
 branches:
   only:

--- a/spec/classes/ipa_spec.rb
+++ b/spec/classes/ipa_spec.rb
@@ -20,6 +20,7 @@ describe 'easy_ipa', type: :class do
       {
         kernel: 'Linux',
         os: {
+          name: 'CentOS',
           family: 'RedHat',
           release: {
             major: '7',


### PR DESCRIPTION
* Specified the OS Name to fix .downcase test failure
* Added puppetlabs/cron_core and puppetlabs/k5login_core to .fixtures.yml as these have been split out of the Puppet v6
* Fix rubygems-update for ruby older than 2.3: Borrowed fixes from: https://github.com/puppetlabs/pdk-templates/pull/171