### PR TITLE
Officially support CentOS 6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class easy_ipa::params {
   case $facts['os']['family'] {
     'RedHat': {
       case $facts['os']['release']['major'] {
-        /(7)/:   { }
+        /(6|7)/:   { }
         default: { fail('ERROR: unsupported operating system') }
       }
       $ldaputils_package_name = 'openldap-clients'


### PR DESCRIPTION
This module seems to work fine on CentOS 6, at least when using the client role.
Therefore do not fail in params.pp.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>