### PR TITLE
Enable --force-join based on $::ipa_force_join fact

### DIFF
--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -40,6 +40,12 @@ class easy_ipa::install::client {
     $client_install_cmd_opts_hostname = ''
   }
 
+  if $::ipa_force_join {
+    $client_install_cmd_opts_force_join= '--force-join'
+  } else {
+    $client_install_cmd_opts_force_join = ''
+  }
+
     $client_install_cmd = "\
 /usr/sbin/ipa-client-install \
   --server=${easy_ipa::ipa_master_fqdn} \
@@ -51,6 +57,7 @@ class easy_ipa::install::client {
   ${client_install_cmd_opts_mkhomedir} \
   ${client_install_cmd_opts_fixed_primary} \
   ${client_install_cmd_opts_no_ntp} \
+  ${client_install_cmd_opts_force_join} \
   ${easy_ipa::opt_no_ssh} \
   ${easy_ipa::opt_no_sshd} \
   --unattended"


### PR DESCRIPTION
The idea is to allow force-joining nodes automatically when they're reprovisioned with the same hostname. This tends to happen rather frequently with clusters and cloud VMs. The fact can be generated prior to the first Puppet run and removed afterwards, or its value can just resolve to false after the first boot.