### PR TITLE
Vagrant: switch to using official centos/7 boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure("2") do |config|
         box.vm.network "forwarded_port", guest: 8000, host: 8000
         box.vm.network "forwarded_port", guest: 8440, host: 8440
         box.vm.provision "shell", path: "vagrant/common.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-1.sh"
     end
 
@@ -35,6 +36,7 @@ Vagrant.configure("2") do |config|
         end
         box.vm.network "private_network", ip: "192.168.44.36"
         box.vm.provision "shell", path: "vagrant/common.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-2.sh"
     end
 
@@ -51,6 +53,7 @@ Vagrant.configure("2") do |config|
         end
         box.vm.network "private_network", ip: "192.168.44.37"
         box.vm.provision "shell", path: "vagrant/common.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 Vagrant.configure("2") do |config|
 
     config.vm.define "ipa-server-1" do |box|
-        box.vm.box = "bento/centos-7.3"
+        box.vm.box = "centos/7"
+        box.vm.box_version = "1901.01"
         box.vm.hostname = 'ipa-server-1.vagrant.example.lan'
         # Assign this VM to a host-only network IP, allowing you to access it
         # via the IP.
@@ -22,7 +23,8 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.define "ipa-server-2" do |box|
-        box.vm.box = "bento/centos-7.3"
+        box.vm.box = "centos/7"
+        box.vm.box_version = "1901.01"
         box.vm.hostname = 'ipa-server-2.vagrant.example.lan'
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
@@ -37,7 +39,8 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.define "ipa-client-1" do |box|
-        box.vm.box = "bento/centos-7.3"
+        box.vm.box = "centos/7"
+        box.vm.box_version = "1901.01"
         box.vm.hostname = 'ipa-client-1.vagrant.example.lan'
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetfinland-easy_ipa",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "Puppet-Finland team",
   "summary": "Manages IPA servers and clients.",
   "license": "Apache-2.0",

--- a/vagrant/centos-7-disable-nm.sh
+++ b/vagrant/centos-7-disable-nm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Recent CentOS images have NetworkManager enabled. As it breaks IPA server's
+# /etc/resolv.conf we don't want to use it.
+puppet apply -e "service { 'NetworkManager': ensure => 'stopped', enable => false, }"


### PR DESCRIPTION
With bento/centos-7.3 virtualbox-vbguest no longer worked. Centos/7 seems to be a drop-in replacement and does not have vbguest issues.