### PR TITLE
fix admin.keytab file/chown_admin_keytab exec ordering

### DIFF
--- a/manifests/config/admin_user.pp
+++ b/manifests/config/admin_user.pp
@@ -17,17 +17,15 @@ class easy_ipa::config::admin_user {
   }
 
   file { $k5login_path:
-    owner   => $uid_number,
-    group   => $uid_number,
-    require => File[$home_dir_path],
+    owner => $uid_number,
+    group => $uid_number,
   }
 
   # chown/chmod *after* file is created by kadmin.local
   file { $keytab_path:
-    owner   => $uid_number,
-    group   => $uid_number,
-    mode    => '0600',
-    require => File[$home_dir_path],
+    owner => $uid_number,
+    group => $uid_number,
+    mode  => '0600',
   }
 
   # Gives admin user the host/fqdn principal.

--- a/manifests/config/admin_user.pp
+++ b/manifests/config/admin_user.pp
@@ -13,7 +13,6 @@ class easy_ipa::config::admin_user {
     owner   => $uid_number,
     group   => $uid_number,
     recurse => true,
-    notify  => Exec['configure_admin_keytab'],
     require => Exec["server_install_${easy_ipa::ipa_server_fqdn}"],
   }
 
@@ -23,12 +22,12 @@ class easy_ipa::config::admin_user {
     require => File[$home_dir_path],
   }
 
+  # chown/chmod *after* file is created by kadmin.local
   file { $keytab_path:
     owner   => $uid_number,
     group   => $uid_number,
     mode    => '0600',
     require => File[$home_dir_path],
-    notify  => Exec['configure_admin_keytab'],
   }
 
   # Gives admin user the host/fqdn principal.
@@ -41,21 +40,11 @@ class easy_ipa::config::admin_user {
   # Set keytab for admin user.
   $configure_admin_keytab_cmd = "/usr/sbin/kadmin.local -q \"ktadd -norandkey -k ${keytab_path} admin\" "
   exec { 'configure_admin_keytab':
-    command     => $configure_admin_keytab_cmd,
-    cwd         => $home_dir_path,
-    unless      => shellquote('/usr/bin/kvno', '-k', $keytab_path, "admin@${easy_ipa::final_realm}"),
-    notify      => Exec['chown_admin_keytab'],
-    refreshonly => true,
-    require     => Cron['k5start_admin'],
-  }
-
-  $chown_admin_keytab_cmd = "chown ${uid_number}:${uid_number} ${keytab_path}"
-  $chown_admin_keytab_cmd_unless = "ls -lan ${keytab_path} | grep ${uid_number}\\ ${uid_number} "
-  exec { 'chown_admin_keytab':
-    command  => $chown_admin_keytab_cmd,
-    cwd      => $home_dir_path,
-    unless   => $chown_admin_keytab_cmd_unless,
-    provider => shell,
+    command => $configure_admin_keytab_cmd,
+    cwd     => $home_dir_path,
+    unless  => shellquote('/usr/bin/kvno', '-k', $keytab_path, "admin@${easy_ipa::final_realm}"),
+    require => File[$home_dir_path],
+    notify  => File[$keytab_path],
   }
 
   $k5start_admin_keytab_cmd = "/sbin/runuser -l admin -c \"/usr/bin/k5start -f ${keytab_path} -U\""
@@ -65,9 +54,10 @@ class easy_ipa::config::admin_user {
     cwd     => $home_dir_path,
     unless  => $k5start_admin_keytab_cmd_unless,
     require => [
+      File[$k5login_path],
+      File[$keytab_path],
       Cron['k5start_admin'],
-      Exec['chown_admin_keytab'],
-    ]
+    ],
   }
 
   # Automatically refreshes admin keytab.
@@ -75,12 +65,9 @@ class easy_ipa::config::admin_user {
     command => "/usr/bin/k5start -f ${keytab_path} -U > /dev/null 2>&1",
     user    => 'admin',
     minute  => '*/1',
-    notify  => Exec['chown_admin_keytab'],
     require => [
-      Package[$::easy_ipa::params::kstart_package_name],
-      K5login[$k5login_path],
-      File[$home_dir_path]
+      File[$k5login_path],
+      File[$keytab_path],
     ],
   }
-
 }

--- a/manifests/config/admin_user.pp
+++ b/manifests/config/admin_user.pp
@@ -17,8 +17,9 @@ class easy_ipa::config::admin_user {
   }
 
   file { $k5login_path:
-    owner => $uid_number,
-    group => $uid_number,
+    owner   => $uid_number,
+    group   => $uid_number,
+    seluser => 'user_u',
   }
 
   # chown/chmod *after* file is created by kadmin.local

--- a/manifests/config/admin_user.pp
+++ b/manifests/config/admin_user.pp
@@ -37,11 +37,14 @@ class easy_ipa::config::admin_user {
   }
 
   # Set keytab for admin user.
+  # kadmin.local must be run as `root` to log to `/var/log/kadmind.log`
   $configure_admin_keytab_cmd = "/usr/sbin/kadmin.local -q \"ktadd -norandkey -k ${keytab_path} admin\" "
+  # kvno must be run as the `admin` user to function
+  $configure_admin_keytab_cmd_unless = "/sbin/runuser -l admin -c \"/usr/bin/kvno -k ${keytab_path} admin@${easy_ipa::final_realm}\""
   exec { 'configure_admin_keytab':
     command => $configure_admin_keytab_cmd,
     cwd     => $home_dir_path,
-    unless  => shellquote('/usr/bin/kvno', '-k', $keytab_path, "admin@${easy_ipa::final_realm}"),
+    unless  => $configure_admin_keytab_cmd_unless,
     require => File[$home_dir_path],
     notify  => File[$keytab_path],
   }


### PR DESCRIPTION
Resolves this error:

    Error: 'chown 20019:20019 /home/admin/admin.keytab' returned 1 instead of one of [0]
    Error: /Stage[main]/Easy_ipa::Config::Admin_user/Exec[chown_admin_keytab]/returns: change from 'notrun' to ['0'] failed: 'chown 20019:20019 /home/admin/admin.keytab' returned 1 instead of one of [0] (corrective)