### PR TITLE
Add support for --enable-dns-updates client install option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,9 @@
 # `domain_join_password`
 #      (string) The password for the domain_join_principal.
 #
+# `enable_dns_updates`
+#      (boolean) If true, then the parameter '--enable-dns-updates' is passed to the IPA installer.
+#
 # `enable_hostname`
 #      (boolean) If true, then the parameter '--hostname' is populated with the parameter 'ipa_server_fqdn'
 #                and passed to the IPA installer.
@@ -170,6 +173,7 @@ class easy_ipa (
   Array[String] $custom_dns_forwarders              = [],
   String        $domain_join_principal              = '',
   String        $domain_join_password               = '',
+  Boolean       $enable_dns_updates                 = false,
   Boolean       $enable_hostname                    = true,
   Boolean       $enable_ip_address                  = false,
   Boolean       $fixed_primary                      = false,

--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -34,6 +34,12 @@ class easy_ipa::install::client {
     $client_install_cmd_opts_no_ntp = '--no-ntp'
   }
 
+  if $easy_ipa::enable_dns_updates {
+    $client_install_cmd_opts_dns_updates = "--enable-dns-updates"
+  } else {
+    $client_install_cmd_opts_dns_updates = ''
+  }
+
   if $easy_ipa::enable_hostname {
     $client_install_cmd_opts_hostname = "--hostname=${::fqdn}"
   } else {
@@ -53,6 +59,7 @@ class easy_ipa::install::client {
   --domain=${easy_ipa::domain} \
   --principal='${easy_ipa::final_domain_join_principal}' \
   --password='${easy_ipa::final_domain_join_password}' \
+  ${client_install_cmd_opts_dns_updates} \
   ${client_install_cmd_opts_hostname} \
   ${client_install_cmd_opts_mkhomedir} \
   ${client_install_cmd_opts_fixed_primary} \


### PR DESCRIPTION
It seems that on CentOS 7 this is somehow the default. But not so on Ubuntu 18.04, so with this addition we can make the parameter default.