### PR TITLE
Vagrant: use an external, generic Puppet installation script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.define "ipa-server-1" do |box|
         box.vm.box = "centos/7"
-        box.vm.box_version = "1901.01"
+        box.vm.box_version = "1905.01"
         box.vm.hostname = 'ipa-server-1.vagrant.example.lan'
         # Assign this VM to a host-only network IP, allowing you to access it
         # via the IP.
@@ -20,12 +20,13 @@ Vagrant.configure("2") do |config|
         box.vm.network "forwarded_port", guest: 8440, host: 8440
         box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-1.sh"
     end
 
     config.vm.define "ipa-server-2" do |box|
         box.vm.box = "centos/7"
-        box.vm.box_version = "1901.01"
+        box.vm.box_version = "1905.01"
         box.vm.hostname = 'ipa-server-2.vagrant.example.lan'
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
@@ -37,12 +38,13 @@ Vagrant.configure("2") do |config|
         box.vm.network "private_network", ip: "192.168.44.36"
         box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-2.sh"
     end
 
     config.vm.define "ipa-client-1" do |box|
         box.vm.box = "centos/7"
-        box.vm.box_version = "1901.01"
+        box.vm.box_version = "1905.01"
         box.vm.hostname = 'ipa-client-1.vagrant.example.lan'
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
@@ -54,6 +56,7 @@ Vagrant.configure("2") do |config|
         box.vm.network "private_network", ip: "192.168.44.37"
         box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
+        box.vm.provision "shell", path: "vagrant/centos-7.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,9 +18,8 @@ Vagrant.configure("2") do |config|
         box.vm.network "private_network", ip: "192.168.44.35"
         box.vm.network "forwarded_port", guest: 8000, host: 8000
         box.vm.network "forwarded_port", guest: 8440, host: 8440
-        box.vm.provision "shell", path: "vagrant/common.sh"
-        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/centos-7.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-1.sh"
     end
 
@@ -36,9 +35,8 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
         box.vm.network "private_network", ip: "192.168.44.36"
-        box.vm.provision "shell", path: "vagrant/common.sh"
-        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/centos-7.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-server-2.sh"
     end
 
@@ -54,9 +52,8 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
         box.vm.network "private_network", ip: "192.168.44.37"
-        box.vm.provision "shell", path: "vagrant/common.sh"
-        box.vm.provision "shell", path: "vagrant/centos-7-disable-nm.sh"
         box.vm.provision "shell", path: "vagrant/centos-7.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 
@@ -72,10 +69,8 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
         box.vm.network "private_network", ip: "192.168.44.38"
-        box.vm.provision "shell" do |s|
-          s.path = "vagrant/debian.sh"
-          s.args = ["xenial"]
-        end
+        box.vm.provision "shell", path: "vagrant/debian.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 
@@ -91,10 +86,8 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
         box.vm.network "private_network", ip: "192.168.44.39"
-        box.vm.provision "shell" do |s|
-          s.path = "vagrant/debian.sh"
-          s.args = ["trusty"]
-        end
+        box.vm.provision "shell", path: "vagrant/debian.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 
@@ -110,10 +103,25 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
         box.vm.network "private_network", ip: "192.168.44.40"
-        box.vm.provision "shell" do |s|
-          s.path = "vagrant/debian.sh"
-          s.args = ["stretch"]
+        box.vm.provision "shell", path: "vagrant/debian.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
+        box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
+    end
+
+    config.vm.define "ipa-client-5" do |box|
+        box.vm.box = "ubuntu/bionic64"
+        box.vm.box_version = "20200225.0.0"
+        box.vm.hostname = 'ipa-client-5.vagrant.example.lan'
+        box.vm.provider 'virtualbox' do |vb|
+            vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
+            vb.gui = false
+            vb.memory = 1024
+            vb.customize ["modifyvm", :id, "--ioapic", "on"]
+            vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
+        box.vm.network "private_network", ip: "192.168.44.41"
+        box.vm.provision "shell", path: "vagrant/debian.sh"
+        box.vm.provision "shell", path: "vagrant/common.sh"
         box.vm.provision "shell", path: "vagrant/ipa-client-1.sh"
     end
 end

--- a/vagrant/centos-7-disable-nm.sh
+++ b/vagrant/centos-7-disable-nm.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# Recent CentOS images have NetworkManager enabled. As it breaks IPA server's
-# /etc/resolv.conf we don't want to use it.
-puppet apply -e "service { 'NetworkManager': ensure => 'stopped', enable => false, }"

--- a/vagrant/centos-7.sh
+++ b/vagrant/centos-7.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+# Without yum upgrade ipa-server-install will fail
+/bin/yum -y upgrade

--- a/vagrant/centos-7.sh
+++ b/vagrant/centos-7.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
-#
-# Without yum upgrade ipa-server-install will fail
+echo I am provisioning...
+export FACTER_is_vagrant='true'
+export PATH=$PATH:/opt/puppetlabs/bin
+
+curl https://raw.githubusercontent.com/Puppet-Finland/scripts/3c1cf163edeebceebd4a29c7c28e6e3a4a11c319/bootstrap/linux/install-puppet.sh -o install-puppet.sh
+/bin/sh install-puppet.sh
 /bin/yum -y upgrade
+
+# Recent CentOS images have NetworkManager enabled. As it breaks IPA server's
+# /etc/resolv.conf we don't want to use it.
+puppet apply -e "service { 'NetworkManager': ensure => 'stopped', enable => false, }"

--- a/vagrant/common.sh
+++ b/vagrant/common.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
-echo I am provisioning...
-export FACTER_is_vagrant='true'
-rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-yum install -y puppet-agent yum-utils
-yum-config-manager --save --setopt=puppetlabs-pc1.skip_if_unavailable=true
 export PATH=$PATH:/opt/puppetlabs/bin
 puppet module install puppetlabs-concat
 puppet module install puppetlabs-stdlib

--- a/vagrant/debian.sh
+++ b/vagrant/debian.sh
@@ -1,17 +1,5 @@
 #!/bin/sh
-DISTRO=$1
 echo I am provisioning...
 export FACTER_is_vagrant='true'
-wget https://apt.puppetlabs.com/puppetlabs-release-pc1-$DISTRO.deb -O puppetlabs-release-pc1-$DISTRO.deb
-dpkg -i puppetlabs-release-pc1-$DISTRO.deb
-apt-get update
-apt-get -y install puppet-agent
-export PATH=$PATH:/opt/puppetlabs/bin
-puppet module install puppetlabs-concat
-puppet module install puppetlabs-stdlib
-puppet module install crayfishx-firewalld
-puppet module install puppet-selinux
-puppet module install saz-resolv_conf
-if [ -d /tmp/modules/easy_ipa ]; then rm -rf /tmp/modules/easy_ipa; fi
-mkdir -p /tmp/modules/easy_ipa
-cp -r /vagrant/* /tmp/modules/easy_ipa
+wget https://raw.githubusercontent.com/Puppet-Finland/scripts/3c1cf163edeebceebd4a29c7c28e6e3a4a11c319/bootstrap/linux/install-puppet.sh
+/bin/sh install-puppet.sh


### PR DESCRIPTION
With many Vagrant, Terraform, Ansible and Puppet Bolt repositories around there there's really no point in reinventing the "install puppet" wheel in every project. This commit also add an Ubuntu 18.04 IPA client as ipa-client-5 - the change which triggered all this refactoring. The script is locked to a specific commit so changes to the "master" branch won't break Vagrant bootstrapping in this repository.