### PR TITLE
Parameter `gssapi_no_negotiate` should be optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,7 +176,7 @@ class easy_ipa (
   Boolean       $enable_hostname                    = true,
   Boolean       $enable_ip_address                  = false,
   Boolean       $fixed_primary                      = false,
-  Pattern       $gssapi_no_negotiate                = false,
+  Variant[Pattern,Undef] $gssapi_no_negotiate       = undef,
   Integer       $idstart                            = (fqdn_rand('10737') + 10000),
   Variant[Integer,Undef] $idmax                     = undef,
   Boolean       $install_autofs                     = false,


### PR DESCRIPTION
Resolves the following error when the parameter is not specified when calling the class.
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Easy_ipa]: parameter 'gssapi_no_negotiate' expects a match for Pattern, got Boolean
```
Fixes a regression introduced in `e74c3bbac991363b09b80ad560aa83cb1663480d`