### PR TITLE
Debian 11 and Ubuntu 22.04 Support

### DIFF
--- a/manifests/install/client/debian.pp
+++ b/manifests/install/client/debian.pp
@@ -10,7 +10,7 @@
 class easy_ipa::install::client::debian {
 
   case $facts['os']['distro']['codename'] {
-    /^(xenial|stretch|bionic|focal|buster)$/: {
+    /^(xenial|stretch|bionic|focal|buster|bullseye|jammy)$/: {
 
       # Ensure that required packages are present even if they do not get pulled
       # in as freeipa-client package dependencies

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,9 @@ class easy_ipa::params {
     }
     'Debian': {
       case $facts['os']['distro']['codename'] {
-        /(trusty|xenial|bionic|buster|focal)/: { $ipa_client_package_ensure = 'present' }
-        /(stretch)/:                           { $ipa_client_package_ensure = 'absent' }
-        default:                               { fail('ERROR: unsupported operating system') }
+        /(trusty|xenial|bionic|buster|focal|bullseye|jammy)/: { $ipa_client_package_ensure = 'present' }
+        /(stretch)/:                                          { $ipa_client_package_ensure = 'absent' }
+        default:                                              { fail('ERROR: unsupported operating system') }
       }
       $ldaputils_package_name = 'ldap-utils'
       $ipa_client_package_name = 'freeipa-client'


### PR DESCRIPTION
The major changes contained in this PR:
- Manifests updated to run on Debian 11 Bullseye and Ubuntu 22.04 Jammy Jellyfish
- Upgrade PDK from 1.4 to 2.4

I have prepared the module for a `2.3.0` release using the PDK. I can revert that change if needed.