### PR TITLE
use forge release of puppetlabs/stdlib as fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,6 @@
 fixtures:
-  repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
   forge_modules:
+    stdlib: "puppetlabs/stdlib"
     cron_core:
       repo: "puppetlabs/cron_core"
       ref: "1.0.0"


### PR DESCRIPTION
Github no longer supports git://.

See: https://github.blog/2021-09-01-improving-git-protocol-security-github/