### PR TITLE
use facts hash to access fact values

### DIFF
--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -46,7 +46,7 @@ class easy_ipa::install::client {
     $client_install_cmd_opts_hostname = ''
   }
 
-  if $::ipa_force_join {
+  if $facts['ipa_force_join'] {
     $client_install_cmd_opts_force_join= '--force-join'
   } else {
     $client_install_cmd_opts_force_join = ''


### PR DESCRIPTION
This is needed to fix spec execution and resolve these error messages:

      1) easy_ipa on Centos as client with defaults is expected to contain Class[easy_ipa::install]
         Failure/Error: it { is_expected.to contain_class('easy_ipa::install') }

         Puppet::PreformattedError:
           Evaluation Error: Unknown variable: '::ipa_force_join'. ...