### PR TITLE
prevent passphrases passed to install scripts from printing in logs

### DIFF
--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -77,7 +77,7 @@ class easy_ipa::install::client {
       timeout   => 0,
       unless    => "cat /etc/ipa/default.conf | grep -i \"${easy_ipa::domain}\"",
       creates   => '/etc/ipa/default.conf',
-      logoutput => 'on_failure',
+      logoutput => false,  # prevent passphrases from appearing in puppet log
       before    => Service['sssd'],
       provider  => 'shell',
       require   => Package['ipa-client'],

--- a/manifests/install/server/master.pp
+++ b/manifests/install/server/master.pp
@@ -30,7 +30,7 @@ class easy_ipa::install::server::master {
     timeout   => 0,
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',
-    logoutput => 'on_failure',
+    logoutput => false,  # prevent passphrases from appearing in puppet log
     notify    => Easy_ipa::Helpers::Flushcache["server_${easy_ipa::ipa_server_fqdn}"],
     before    => Service['sssd'],
   }

--- a/manifests/install/server/replica.pp
+++ b/manifests/install/server/replica.pp
@@ -31,7 +31,7 @@ class easy_ipa::install::server::replica {
     timeout   => 0,
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',
-    logoutput => 'on_failure',
+    logoutput => false,  # prevent passphrases from appearing in puppet log
     notify    => Easy_ipa::Helpers::Flushcache["server_${easy_ipa::ipa_server_fqdn}"],
     before    => Service['sssd'],
   }

--- a/spec/classes/ipa_spec.rb
+++ b/spec/classes/ipa_spec.rb
@@ -84,8 +84,11 @@ describe 'easy_ipa', type: :class do
           end
 
           it do
-            is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--idstart=10000})
-            is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--idmax=20000})
+            is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+              logoutput: false
+            ).
+              with_command(%r{--idstart=10000}).
+              with_command(%r{--idmax=20000})
           end
         end
 
@@ -95,7 +98,9 @@ describe 'easy_ipa', type: :class do
           end
 
           it do
-            is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--idstart=10000})
+            is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+              logoutput: false
+            ).with_command(%r{--idstart=10000})
             is_expected.not_to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--idmax})
           end
         end
@@ -114,7 +119,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_ssh: false)
             end
 
-            it { is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--no-ssh(?!d)}) }
+            it {
+              is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-ssh(?!d)})
+            }
           end
         end
 
@@ -132,7 +141,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_sshd: false)
             end
 
-            it { is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--no-sshd}) }
+            it {
+              is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-sshd})
+            }
           end
         end
 
@@ -255,7 +268,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_ssh: false)
             end
 
-            it { is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--no-ssh(?!d)}) }
+            it {
+              is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-ssh(?!d)})
+            }
           end
         end
 
@@ -273,7 +290,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_sshd: false)
             end
 
-            it { is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with_command(%r{--no-sshd}) }
+            it {
+              is_expected.to contain_exec('server_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-sshd})
+            }
           end
         end
 
@@ -354,7 +375,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_ssh: false)
             end
 
-            it { is_expected.to contain_exec('client_install_ipa.rpsec.example.lan').with_command(%r{--no-ssh(?!d)}) }
+            it {
+              is_expected.to contain_exec('client_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-ssh(?!d)})
+            }
           end
         end
 
@@ -372,7 +397,11 @@ describe 'easy_ipa', type: :class do
               super().merge(configure_sshd: false)
             end
 
-            it { is_expected.to contain_exec('client_install_ipa.rpsec.example.lan').with_command(%r{--no-sshd}) }
+            it {
+              is_expected.to contain_exec('client_install_ipa.rpsec.example.lan').with(
+                logoutput: false
+              ).with_command(%r{--no-sshd})
+            }
           end
         end
 


### PR DESCRIPTION
By setting `logoutput` to `false` on the `exec` resource for install scripts, we prevent script args such as `--admin-password` from appearing in the puppet agent report logs.