### PR TITLE
Add support for Debian 12 Bookworm

### DIFF
--- a/manifests/install/client/debian.pp
+++ b/manifests/install/client/debian.pp
@@ -1,6 +1,6 @@
 #
 # @summary Ensure that home directories get created on Debian and Ubuntu clients.
-# 
+#
 # This code is needed as the --mkhomedir parameter passed to ipa-client-install does
 # not configure PAM even though it does install the required packages.
 #
@@ -8,7 +8,7 @@
 #
 class easy_ipa::install::client::debian {
   case $facts['os']['distro']['codename'] {
-    /^(xenial|stretch|bionic|focal|buster|bullseye|jammy)$/: {
+    /^(xenial|stretch|bionic|focal|buster|bullseye|jammy|bookworm)$/: {
       # Ensure that required packages are present even if they do not get pulled
       # in as freeipa-client package dependencies
       stdlib::ensure_packages(['oddjob','oddjob-mkhomedir'], { 'ensure' => 'present' })

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class easy_ipa::params {
     }
     'Debian': {
       case $facts['os']['distro']['codename'] {
-        /(trusty|xenial|bionic|buster|focal|bullseye|jammy)/: { $ipa_client_package_ensure = 'present' }
+        /(trusty|xenial|bionic|buster|focal|bullseye|jammy|bookworm)/: { $ipa_client_package_ensure = 'present' }
         /(stretch)/:                                          { $ipa_client_package_ensure = 'absent' }
         default:                                              { fail('ERROR: unsupported operating system') }
       }


### PR DESCRIPTION
I wasn't able to test the Vagrant changes due to hardware constraints. It's included for completeness, but I can remove them if its not needed.